### PR TITLE
fix: auto-resolve PR review conversation threads

### DIFF
--- a/docs/current.md
+++ b/docs/current.md
@@ -1,6 +1,5 @@
 STATE: completed
-TASK: Refactor specialist TDD to autonomous via TDG plugin (ruaysud/multi-agent-auto-skill PR 86)
-SINCE: 2026-02-10 01:13
-ISSUE: ruaysud/multi-agent-auto-skill#86
-BRANCH: main (merged from refactor/tdd-autonomous-specialist)
+TASK: Auto-resolve PR review conversation threads (#15)
+SINCE: 2026-03-05 01:54
+ISSUE: #15
 LANGUAGE: en

--- a/docs/current.md
+++ b/docs/current.md
@@ -2,4 +2,5 @@ STATE: completed
 TASK: Auto-resolve PR review conversation threads (#15)
 SINCE: 2026-03-05 01:54
 ISSUE: #15
+BRANCH: main
 LANGUAGE: en

--- a/docs/logs/activity.log
+++ b/docs/logs/activity.log
@@ -47,3 +47,4 @@
 2026-02-09 12:08 | completed | Add --label and --points flags to jira create and create-subtask commands
 2026-02-09 12:38 | completed | Add --due flag to jira create command (#104) - PR #105 merged
 2026-02-10 01:14 | completed | Refactor specialist TDD to autonomous via TDG plugin (multi-agent-auto-skill PR #86)
+2026-03-05 01:58 | completed | Auto-resolve PR review conversation threads (#15)

--- a/docs/retrospective/2026-03/retrospective_2026-03-05_015400.md
+++ b/docs/retrospective/2026-03/retrospective_2026-03-05_015400.md
@@ -1,0 +1,133 @@
+---
+date: 2026-03-05T01:54:00+07:00
+type: bugfix
+tags: [pr-review, thread-resolution, github-api]
+branch: main
+issue: "#15"
+duration: ~30m
+files_changed:
+  - skills/pr-review/SKILL.md
+  - skills/pr-review/thread-resolution.md
+---
+
+# Auto-resolve PR Review Conversation Threads
+
+## Session Metadata
+
+| Field | Value |
+|-------|-------|
+| Date | 2026-03-05 |
+| Time | 01:54:00 (Asia/Bangkok) |
+| Duration | ~30m |
+| Focus | Inline thread resolution into pr-review Steps 6.1-6.5 |
+| Type | Bugfix |
+| Branch | main |
+| Issue | #15 |
+
+---
+
+## Context: Before
+
+- **Problem**: After `/pr-review` replies to review comments, conversation threads remain open on GitHub PR — user must manually resolve each thread
+- **Existing Behavior**: Step 6.6 existed as a one-liner pointing to `thread-resolution.md`, but resolve calls were not inlined in Steps 6.1-6.5, so Claude didn't consistently resolve threads
+- **Why Change**: Manual thread resolution is tedious and defeats the purpose of automated PR review handling
+
+---
+
+## Context: After
+
+- **Solution**: Inlined `get_thread_id_for_comment` + `resolve_thread` calls directly into each reply step (6.1-6.5), making thread resolution an integral part of each reply action
+- **New Behavior**: Each comment reply is immediately followed by thread resolution. Step 6.6 now serves as a verification check for any missed threads
+- **Improvements**: Threads are resolved consistently and automatically after every reply type
+
+---
+
+## Decisions & Rationale
+
+| Decision | Options Considered | Chosen | Rationale |
+|----------|-------------------|--------|-----------|
+| Where to place resolve calls | Separate step (6.6) vs inline in 6.1-6.5 | Inline in 6.1-6.5 | Ensures Claude always resolves immediately after reply — no gap where it might skip |
+| What to do with Step 6.6 | Remove it vs convert to verification | Convert to verification | Provides a safety net to catch any missed threads |
+| Helper function reference | Inline the functions vs reference file | Reference file | Functions already exist in `thread-resolution.md`, avoid duplication |
+
+---
+
+## Session Summary
+
+### Task Description
+Issue #15: PR review conversation threads stay open after `/pr-review` replies. Need to auto-resolve threads inline.
+
+### Outcome
+All 5 reply steps (6.1-6.5) now include resolve blocks. Step 6.6 converted to verification. Helper reference added before Step 6.1.
+
+---
+
+## Technical Details
+
+### Files Modified
+
+| File | Changes |
+|------|---------|
+| `skills/pr-review/SKILL.md` | Added helper reference note, inlined resolve blocks in 6.1-6.5, rewrote 6.6 as verification step |
+| `skills/pr-review/thread-resolution.md` | Updated fallback docs to reflect inline resolution in 6.1-6.5 |
+
+### Key Implementation Details
+
+- Each resolve block follows the same pattern: `get_thread_id_for_comment` → `resolve_thread`
+- For Step 6.5 (defer), resolve is step 3 inside the same code block (after issue create + reply)
+- For Steps 6.1-6.4, resolve is a separate code block after the reply block
+- Step 6.6 uses a GraphQL query to count remaining unresolved threads
+
+---
+
+## Honest Feedback
+
+### What Went Well
+- Clean, focused change — only modified what was needed
+- Pattern is consistent across all 5 steps
+
+### What Could Be Improved
+- Could add error handling for resolve failures (currently silent)
+
+### Blockers Encountered
+- None
+
+---
+
+## Lessons Learned
+
+### Technical Insights
+- Separating resolve into its own step creates a gap where LLM may skip it — inlining is more reliable for LLM-executed workflows
+
+### Process Improvements
+- When designing LLM skill instructions, critical actions should be inlined with the primary action rather than separated into follow-up steps
+
+---
+
+## Next Steps
+
+### Immediate
+- [x] Commit and push changes
+- [ ] Test with actual PR review to verify threads resolve correctly
+
+### Future Improvements
+- [ ] Add error handling/retry for thread resolution failures
+- [ ] Consider batch resolution as optimization for PRs with many comments
+
+---
+
+## Validation Checklist
+
+- [x] Changes committed with atomic commits
+- [x] Consistent with existing code patterns
+- [x] No hardcoded values
+- [x] Resolve calls present in all Steps 6.1-6.5
+- [x] Step 6.6 serves as verification fallback
+
+---
+
+## Related
+
+- **Issue**: #15
+- **Commit**: `60570f3` fix: inline thread resolution into pr-review Steps 6.1-6.5
+- **Reference**: `skills/pr-review/thread-resolution.md` — GraphQL helpers

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -128,6 +128,10 @@ COMMIT_HASH=$(git rev-parse --short HEAD)
 # IMPORTANT: ใส่ commit hash เพื่อให้ reviewer trace ได้
 gh api repos/{owner}/{repo}/pulls/{pr_number}/comments/{comment_id}/replies \
   -f body="Fixed in ${COMMIT_HASH}! [description of what was changed]"
+
+# 4. Resolve thread
+THREAD_ID=$(get_thread_id_for_comment "$owner" "$repo" "$pr_number" "$comment_id")
+[[ -n "$THREAD_ID" ]] && resolve_thread "$THREAD_ID"
 ```
 
 **หมายเหตุ:**
@@ -146,12 +150,6 @@ gh api repos/{owner}/{repo}/pulls/{pr_number}/comments/{comment_id}/replies \
 rm /tmp/reply.txt
 ```
 
-```bash
-# Resolve thread
-THREAD_ID=$(get_thread_id_for_comment "$owner" "$repo" "$pr_number" "$comment_id")
-[[ -n "$THREAD_ID" ]] && resolve_thread "$THREAD_ID"
-```
-
 #### 6.2 Comment ที่ไม่ต้องแก้ไข
 
 ```bash
@@ -162,9 +160,7 @@ gh api repos/{owner}/{repo}/pulls/{pr_number}/comments/{comment_id}/replies \
 [explanation why not changing]
 
 [alternative approach if applicable]"
-```
 
-```bash
 # Resolve thread
 THREAD_ID=$(get_thread_id_for_comment "$owner" "$repo" "$pr_number" "$comment_id")
 [[ -n "$THREAD_ID" ]] && resolve_thread "$THREAD_ID"
@@ -176,9 +172,7 @@ THREAD_ID=$(get_thread_id_for_comment "$owner" "$repo" "$pr_number" "$comment_id
 # Reply ไปที่ comment_id นั้นโดยตรง (ห้ามรวมกับ comment อื่น)
 gh api repos/{owner}/{repo}/pulls/{pr_number}/comments/{comment_id}/replies \
   -f body="[answer to question]"
-```
 
-```bash
 # Resolve thread
 THREAD_ID=$(get_thread_id_for_comment "$owner" "$repo" "$pr_number" "$comment_id")
 [[ -n "$THREAD_ID" ]] && resolve_thread "$THREAD_ID"
@@ -190,9 +184,7 @@ THREAD_ID=$(get_thread_id_for_comment "$owner" "$repo" "$pr_number" "$comment_id
 # Reply ไปที่ comment_id นั้นโดยตรง
 gh api repos/{owner}/{repo}/pulls/{pr_number}/comments/{comment_id}/replies \
   -f body="Thank you! [brief acknowledgment]"
-```
 
-```bash
 # Resolve thread
 THREAD_ID=$(get_thread_id_for_comment "$owner" "$repo" "$pr_number" "$comment_id")
 [[ -n "$THREAD_ID" ]] && resolve_thread "$THREAD_ID"

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -110,6 +110,8 @@ gh api repos/{owner}/{repo}/issues/{pr_number}/comments --jq '.[] | {id, body, u
 - ห้ามสร้าง comment ใหม่แยกต่างหาก
 - ต้อง reply ไปที่ comment นั้นๆ โดยตรงเท่านั้น
 
+**Thread Resolution:** ใช้ helper functions จาก [thread-resolution.md](thread-resolution.md) — `get_thread_id_for_comment(owner, repo, pr_number, comment_id)` และ `resolve_thread(thread_id)`
+
 สำหรับ **แต่ละ comment** ให้ทำแยกกัน:
 
 #### 6.1 Comment ที่ต้องแก้ไข
@@ -144,6 +146,12 @@ gh api repos/{owner}/{repo}/pulls/{pr_number}/comments/{comment_id}/replies \
 rm /tmp/reply.txt
 ```
 
+```bash
+# Resolve thread
+THREAD_ID=$(get_thread_id_for_comment "$owner" "$repo" "$pr_number" "$comment_id")
+[[ -n "$THREAD_ID" ]] && resolve_thread "$THREAD_ID"
+```
+
 #### 6.2 Comment ที่ไม่ต้องแก้ไข
 
 ```bash
@@ -156,6 +164,12 @@ gh api repos/{owner}/{repo}/pulls/{pr_number}/comments/{comment_id}/replies \
 [alternative approach if applicable]"
 ```
 
+```bash
+# Resolve thread
+THREAD_ID=$(get_thread_id_for_comment "$owner" "$repo" "$pr_number" "$comment_id")
+[[ -n "$THREAD_ID" ]] && resolve_thread "$THREAD_ID"
+```
+
 #### 6.3 Comment ที่เป็นคำถาม
 
 ```bash
@@ -164,12 +178,24 @@ gh api repos/{owner}/{repo}/pulls/{pr_number}/comments/{comment_id}/replies \
   -f body="[answer to question]"
 ```
 
+```bash
+# Resolve thread
+THREAD_ID=$(get_thread_id_for_comment "$owner" "$repo" "$pr_number" "$comment_id")
+[[ -n "$THREAD_ID" ]] && resolve_thread "$THREAD_ID"
+```
+
 #### 6.4 Comment ที่เป็นคำชม
 
 ```bash
 # Reply ไปที่ comment_id นั้นโดยตรง
 gh api repos/{owner}/{repo}/pulls/{pr_number}/comments/{comment_id}/replies \
   -f body="Thank you! [brief acknowledgment]"
+```
+
+```bash
+# Resolve thread
+THREAD_ID=$(get_thread_id_for_comment "$owner" "$repo" "$pr_number" "$comment_id")
+[[ -n "$THREAD_ID" ]] && resolve_thread "$THREAD_ID"
 ```
 
 #### 6.5 Comment ที่ต้อง Defer (งานที่จะทำภายหลัง)
@@ -216,6 +242,10 @@ EOF
 # 2. Reply พร้อม issue reference
 gh api repos/{owner}/{repo}/pulls/{pr_number}/comments/{comment_id}/replies \
   -f body="Thanks for the feedback! Created #$DEFER_ISSUE to track this work."
+
+# 3. Resolve thread
+THREAD_ID=$(get_thread_id_for_comment "$owner" "$repo" "$pr_number" "$comment_id")
+[[ -n "$THREAD_ID" ]] && resolve_thread "$THREAD_ID"
 ```
 
 **ตัวอย่าง Defer Cases:**
@@ -227,9 +257,30 @@ gh api repos/{owner}/{repo}/pulls/{pr_number}/comments/{comment_id}/replies \
 | "Documentation could be improved" | `docs: improve documentation for [feature]` | `enhancement` |
 | "Performance could be better" | `perf: optimize [operation]` | `enhancement` |
 
-#### 6.6 Resolve Conversation After Reply
+#### 6.6 Verify All Threads Resolved
 
-After replying to each comment, resolve the conversation thread. See [thread-resolution.md](thread-resolution.md) for GraphQL helper functions and detailed resolution logic.
+หลังจาก reply + resolve ทุก comment แล้ว ตรวจสอบว่าไม่มี unresolved threads เหลืออยู่:
+
+```bash
+# Check for any remaining unresolved threads
+UNRESOLVED=$(gh api graphql -f query='
+    query($owner: String!, $repo: String!, $pr: Int!) {
+        repository(owner: $owner, name: $repo) {
+            pullRequest(number: $pr) {
+                reviewThreads(first: 100) {
+                    nodes { isResolved }
+                }
+            }
+        }
+    }
+' -f owner="$owner" -f repo="$repo" -F pr="$pr_number" \
+  --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length')
+
+if [[ "$UNRESOLVED" -gt 0 ]]; then
+    echo "Warning: $UNRESOLVED unresolved threads remaining"
+    # See thread-resolution.md for batch resolution helpers
+fi
+```
 
 ### Step 7: Update Related Issues
 

--- a/skills/pr-review/thread-resolution.md
+++ b/skills/pr-review/thread-resolution.md
@@ -165,7 +165,7 @@ resolve_thread "$THREAD_ID" && echo "Resolved comment 126"
 
 ## Verify All Threads Resolved (Fallback)
 
-Primary resolve happens inline in Step 6.6. This check is for verification and catching missed threads.
+Primary resolve happens inline in Steps 6.1-6.5. Step 6.6 runs this check for verification and catching missed threads.
 
 ```bash
 check_unresolved_threads() {


### PR DESCRIPTION
## Summary

Inline thread resolution into `/pr-review` Steps 6.1-6.5 so conversation threads are automatically resolved after each reply, instead of relying on a separate Step 6.6 that was often skipped.

## Changes Made

- `skills/pr-review/SKILL.md` — inline resolve calls in Steps 6.1-6.5 (merged into same code block as reply), added helper reference note, rewrote Step 6.6 as verification check
- `skills/pr-review/thread-resolution.md` — updated fallback docs to reflect inline resolution
- `docs/current.md` — updated focus state with BRANCH field
- `docs/retrospective/2026-03/retrospective_2026-03-05_015400.md` — session retrospective
- `docs/logs/activity.log` — activity entry

## Testing

| Test | Status |
|------|--------|
| Diff review | Passed — resolve calls present in all 6.1-6.5 |
| Code review | Passed — critical fix applied (BRANCH field), warnings addressed (unified code blocks) |

## Related Issues

Fixes #15