### PR TITLE
feat: /pr-audit skill + /pr-review·/pr language support (#17 #18 #19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,58 @@
+# Changelog
+
+All notable changes to **dev-km** are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- **`/pr-audit` skill** (#19) — reviewer-side deep audit of an open PR by number/URL.
+  - Resolves PR (supports `--repo owner/name` and cross-repo forks).
+  - Clones the PR branch into an isolated **git worktree** (never touches the main working tree) and always runs **build + test** via the `build-validator` subagent.
+  - Deep review via the `code-reviewer` subagent, plus **cross-layer wiring** checks (CI workflow → Dockerfile `ARG`/`ENV` → app runtime, migration → repository, proto → impl).
+  - **KB-first policy**: searches `kb/` before flagging known patterns; stops to ask + records a new KB entry when none exists.
+  - Compares against existing **Copilot / reviewer** comments, dedupes, and replies to disagreements with evidence.
+  - Two modes — `--mode=review` (report in chat) and `--mode=comment` (post **inline conversation** bound to `commit_id`+`path`+`line` **and** a **summary review**).
+  - `--lang=th|en` (default `th`) for posted comments.
+  - Always cleans up the worktree and restores the original branch, even on failure.
+  - Companion reference `skills/pr-audit/known-patterns.md` (e.g. Go **dup-import** is not a compile error — build first; cross-layer wiring checklist).
+- **`/pr-review` Thai reply templates** (#17) — translations for the 6.1–6.5 reply bodies (`Fixed in …`, `Thanks for the suggestion!`, `Thank you!`, `Created #N to track …`) added to `references/language-guide.md`, with a pointer from the skill.
+
+### Changed
+- **Usage docs synced with all skills.** `SKILL.md` and `README.md` skill tables now list `/pr-audit` and distinguish `/pr-review` (own PR) from `/pr-audit` (others' PRs).
+- **Directory-structure docs migrated** in `SKILL.md` and `README.md` from the legacy `docs/{learnings,knowledge-base,retrospective,…}` layout to the `kb/` Obsidian vault layout (`kb/02-patterns`, `kb/03-bugs`, `kb/04-decisions`, `kb/05-ai-reviewed/{learnings,retrospective,summaries}`). `docs/` now documents only repo-local artifacts (`auto-captured`, `shared-knowledge`, `logs`, `current.md`).
+- `ROADMAP.md` records #17/#18/#19 under a completed **v1.3 – i18n, KB Vault & PR Audit** milestone.
+
+### Verified
+- **`/pr` language support** (#18) — confirmed already satisfied by the i18n infrastructure: `/pr` reads `LANGUAGE` from `docs/current.md` and `references/language-guide.md` covers all issue comments and the PR body template. No code change required.
+
+## [0.24.4] - 2026-06-19
+
+### Changed
+- **Knowledge paths migrated `docs/` → `kb/` (Obsidian vault).** All skills and reference templates now read/write the vault layout:
+  - `docs/knowledge-base/` → `kb/02-patterns/<domain>/`
+  - `docs/learnings/` → `kb/05-ai-reviewed/learnings/`
+  - `docs/retrospective/` → `kb/05-ai-reviewed/retrospective/`
+  - `docs/summaries/` → `kb/05-ai-reviewed/summaries/`
+- `/improve` and `references/improve-workflow.md` gained scan priorities for `kb/03-bugs/` (postmortem action items) and `kb/04-decisions/` (ADR action items).
+- `/distill` pattern template gained YAML frontmatter (`tags`, `type`, `domain`, `services`, `date`, `status`) and `[[wiki-link]]` cross-references for the Obsidian graph.
+- `/focus` gained a pre-feature checklist (grep anti-pattern registry, verify data flow in real code, read repo `CLAUDE.md`) and a `PLAN:` field in `docs/current.md`.
+
+## [0.24.x] - 2026-06-19
+
+### Added
+- **i18n infrastructure** — `LANGUAGE` config in `docs/current.md`, `references/language-guide.md` translation reference, and Thai language support across docs/GitHub-artifact skills.
+- Shared `references/bash-helpers.md` for common snippets (TZ, language detection, focus context).
+
+### Fixed
+- `/pr-review` thread resolution inlined into Steps 6.1–6.5 (reply + resolve as one atomic action) with a completion gate verifying zero unresolved threads (#15, #16).
+
+### Changed
+- Extracted large skill content into bundled resource files; replaced inline language preambles with compact references.
+
+---
+
+[Unreleased]: https://github.com/goffity/dev-km/compare/v0.24.4...HEAD
+[0.24.4]: https://github.com/goffity/dev-km/releases/tag/v0.24.4

--- a/README.md
+++ b/README.md
@@ -75,16 +75,17 @@ npx skills remove dev-km
 | `/commit` | Atomic commits (via TDG) | `/commit` |
 | `/pr` | Test + Build + Review + Create PR + Auto-respond | `/pr` |
 | `/review` | Manual code review | `/review` |
-| `/pr-review` | ตอบ PR feedback | `/pr-review` |
+| `/pr-review` | ตอบ PR feedback (PR ของตัวเอง) | `/pr-review` |
+| `/pr-audit` | รีวิว PR คนอื่นเชิงลึก (clone+build, inline+summary) | `/pr-audit 351 --mode=comment` |
 | `/pr-poll` | จัดการ PR review polling daemon | `/pr-poll start` / `/pr-poll auto` |
 
 ### Knowledge Capture (4-Layer)
 
 | Command | Layer | Purpose | Output |
 |---------|-------|---------|--------|
-| `/mem [topic]` | 1 | Quick capture ระหว่างงาน | `docs/learnings/YYYY-MM/DD/HH.MM_slug.md` |
-| `/distill [topic]` | 2 | Extract patterns | `docs/knowledge-base/[topic].md` |
-| `/td` | 3 | Post-task retrospective | `docs/retrospective/YYYY-MM/retrospective_*.md` |
+| `/mem [topic]` | 1 | Quick capture ระหว่างงาน | `kb/05-ai-reviewed/learnings/YYYY-MM/DD/HH.MM_slug.md` |
+| `/distill [topic]` | 2 | Extract patterns | `kb/02-patterns/<domain>/[topic].md` |
+| `/td` | 3 | Post-task retrospective | `kb/05-ai-reviewed/retrospective/YYYY-MM/retrospective_*.md` |
 | `/improve` | 4 | Work on pending items | Implementation |
 
 ### Knowledge & Docs
@@ -98,7 +99,7 @@ npx skills remove dev-km
 | `/example [lang] [name]` | Save code examples | `/example go retry-backoff` |
 | `/flow [name]` | Process flow diagrams | `/flow deployment` |
 | `/pattern [name]` | Design pattern docs | `/pattern retry-with-backoff` |
-| `/share [path]` | Cross-project knowledge sharing | `/share docs/knowledge-base/topic.md` |
+| `/share [path]` | Cross-project knowledge sharing | `/share kb/02-patterns/topic.md` |
 
 ### Integration & Config
 
@@ -194,14 +195,14 @@ npx skills remove dev-km
                          ▼
 ┌─────────────────────────────────────────────────────────────────┐
 │  Layer 1: /mem                                                  │
-│  Quick capture → docs/learnings/YYYY-MM/DD/HH.MM_slug.md       │
+│  Quick capture → kb/05-ai-reviewed/learnings/YYYY-MM/DD/...    │
 └─────────────────────────────────────────────────────────────────┘
                          │
                          │ (เมื่อมี 3+ learnings เรื่องเดียวกัน)
                          ▼
 ┌─────────────────────────────────────────────────────────────────┐
 │  Layer 2: /distill                                              │
-│  Extract patterns → docs/knowledge-base/topic.md               │
+│  Extract patterns → kb/02-patterns/<domain>/topic.md           │
 └─────────────────────────────────────────────────────────────────┘
                          │
                          │ (periodic review)
@@ -297,16 +298,16 @@ project/
 
 ```bash
 # Find by type
-grep -l "type: bugfix" docs/retrospective/**/*.md
+grep -l "type: bugfix" kb/05-ai-reviewed/retrospective/**/*.md
 
 # Search content
-grep -r "mongodb" docs/
+grep -r "mongodb" kb/
 
 # Recent learnings (last 7 days)
-find docs/learnings -name "*.md" -mtime -7
+find kb/05-ai-reviewed/learnings -name "*.md" -mtime -7
 
-# List all decisions
-grep -l "type: decision" docs/retrospective/**/*.md
+# List all decisions (ADRs)
+find kb/04-decisions -name "*.md"
 ```
 
 ## Skill Structure
@@ -336,6 +337,9 @@ dev-km/
 │   │   ├── SKILL.md
 │   │   ├── thread-resolution.md   # GraphQL thread resolve helpers
 │   │   └── copilot-reviews.md     # Copilot review handling
+│   ├── pr-audit/                   # /pr-audit - Reviewer-side deep PR review
+│   │   ├── SKILL.md
+│   │   └── known-patterns.md      # KB-first known patterns (dup-import, etc.)
 │   ├── pr-poll/SKILL.md            # /pr-poll - PR review daemon
 │   ├── cleanup/SKILL.md            # /cleanup - Retention policy
 │   ├── consolidate/SKILL.md        # /consolidate - Session merger
@@ -656,7 +660,7 @@ brew install terminal-notifier
       "matcher": "",
       "hooks": [{
         "type": "command",
-        "command": "[ ! -f docs/retrospective/$(date +%Y-%m)/retrospective_$(date +%Y-%m-%d)_*.md ] && ~/.claude/skills/dev-km/scripts/auto-capture.sh . 2>/dev/null || true"
+        "command": "[ ! -f kb/05-ai-reviewed/retrospective/$(date +%Y-%m)/retrospective_$(date +%Y-%m-%d)_*.md ] && ~/.claude/skills/dev-km/scripts/auto-capture.sh . 2>/dev/null || true"
       }]
     }]
   }

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -37,6 +37,16 @@ Dec 2025                    Jan 2026
 
 ## Completed
 
+### v1.3 - i18n, KB Vault & PR Audit ✓
+
+| Issue | Title | Type |
+|-------|-------|------|
+| #15/#16 | Auto-resolve PR review threads (inline 6.1–6.5) | bug |
+| — | Migrate knowledge paths `docs/` → `kb/` Obsidian vault | refactor |
+| #17 | /pr-review language support (TH reply templates 6.1–6.5) | feature |
+| #18 | /pr language support (issue comments + PR body TH) | feature |
+| #19 | New `/pr-audit` skill — reviewer-side deep PR review | feature |
+
 ### v1.1 - Core Fixes & Jira Integration ✓
 
 | Issue | Title | Type |

--- a/SKILL.md
+++ b/SKILL.md
@@ -18,9 +18,9 @@ user-invocable: false
 
 | Skill | Layer | Output | Trigger |
 |-------|-------|--------|---------|
-| `/mem [topic]` | 1 | `docs/learnings/YYYY-MM/DD/HH.MM_slug.md` | Quick insight capture |
-| `/distill [topic]` | 2 | `docs/knowledge-base/[topic].md` | 3+ learnings on same topic |
-| `/td` | 3 | `docs/retrospective/YYYY-MM/retrospective_*.md` | Task completed |
+| `/mem [topic]` | 1 | `kb/05-ai-reviewed/learnings/YYYY-MM/DD/HH.MM_slug.md` | Quick insight capture |
+| `/distill [topic]` | 2 | `kb/02-patterns/<domain>/[topic].md` | 3+ learnings on same topic |
+| `/td` | 3 | `kb/05-ai-reviewed/retrospective/YYYY-MM/retrospective_*.md` | Task completed |
 | `/improve` | 4 | Implementation | Work on pending items |
 | `/recap` | - | Context summary | Start new session |
 | `/focus [task]` | - | Issue + branch | Set current task |
@@ -32,7 +32,8 @@ user-invocable: false
 | `/commit` | Atomic commits via TDG |
 | `/pr` | Tests, build, review, create PR |
 | `/review` | Code review before push |
-| `/pr-review` | Handle PR review feedback |
+| `/pr-review` | Handle PR review feedback (own PR) |
+| `/pr-audit [pr#]` | Reviewer-side deep audit of an open PR (clone+build, inline+summary) |
 | `/pr-poll` | PR review notification daemon |
 
 ## Knowledge & Docs Skills (user-invocable)
@@ -69,21 +70,29 @@ user-invocable: false
 ## Directory Structure
 
 ```
-docs/
-├── learnings/           # /mem output
-│   └── YYYY-MM/DD/
-├── knowledge-base/      # /distill output
-├── retrospective/       # /td output
-│   └── YYYY-MM/
-├── auto-captured/       # Auto-capture output
-├── examples/            # /example output
-├── summaries/           # /summary output
-├── shared-knowledge/    # /share output
-├── flows/               # /flow output
-├── patterns/            # /pattern output
-├── logs/                # Activity log
-└── current.md           # Current focus state
+kb/                          # symlink to Obsidian second-brain vault
+├── 02-patterns/             # /distill, /pattern output (curated patterns)
+│   ├── <domain>/            #   grpc, observability, database, k8s, ...
+│   ├── anti-patterns/       #   anti-pattern registry
+│   ├── examples/            # /example output
+│   └── flows/               # /flow output
+├── 03-bugs/                 # Bug postmortems (scanned by /improve)
+├── 04-decisions/            # ADRs (scanned by /improve)
+└── 05-ai-reviewed/
+    ├── learnings/           # /mem output
+    │   └── YYYY-MM/DD/
+    ├── retrospective/       # /td output
+    │   └── YYYY-MM/
+    └── summaries/           # /summary output
+
+docs/                        # repo-local, NOT in vault
+├── auto-captured/           # Auto-capture output
+├── shared-knowledge/        # /share output
+├── logs/                    # Activity log
+└── current.md               # Current focus state (STATE/TASK/ISSUE/BRANCH/LANGUAGE)
 ```
+
+> `kb/` = symlink to the Obsidian vault. Legacy `docs/{learnings,knowledge-base,retrospective,...}` paths are deprecated.
 
 ## Setup
 

--- a/references/language-guide.md
+++ b/references/language-guide.md
@@ -263,6 +263,21 @@ LANG=$(grep "^LANGUAGE:" docs/current.md 2>/dev/null | cut -d: -f2 | xargs)
 | Created | สร้างเมื่อ |
 | Metric | ตัวชี้วัด |
 
+### /pr-review Reply Templates (6.1–6.5)
+
+Reply bodies ที่โพสต์ตอบ reviewer บน GitHub — แปลตาม LANGUAGE (technical terms เช่น commit hash, issue number คงเดิม)
+
+| Use case | English | Thai |
+|---|---|---|
+| 6.1 Fixed | `Fixed in ${HASH}! [description]` | `แก้แล้วใน ${HASH}! [อธิบายสิ่งที่แก้]` |
+| 6.2 Not changing | `Thanks for the suggestion! [explanation why not changing]` | `ขอบคุณสำหรับข้อเสนอแนะ! [เหตุผลที่ยังไม่เปลี่ยน]` |
+| 6.3 Question | `[answer to question]` | `[คำตอบของคำถาม]` |
+| 6.4 Praise | `Thank you! [brief acknowledgment]` | `ขอบคุณครับ! [รับทราบสั้น ๆ]` |
+| 6.5 Defer | `Thanks for the feedback! Created #N to track this work.` | `ขอบคุณสำหรับ feedback! สร้าง issue #N ไว้ track งานนี้แล้ว` |
+| Defer alt | `Created #N to track this work.` | `สร้าง issue #N ไว้ track งานนี้แล้ว` |
+
+> Learning document commit message (`Step 9`) ยังคงเป็น English เสมอ (conventional commit) — เฉพาะ reply body และ section headings เท่านั้นที่แปล
+
 ## Common Phrases
 
 | English | Thai |

--- a/skills/pr-audit/SKILL.md
+++ b/skills/pr-audit/SKILL.md
@@ -1,0 +1,236 @@
+---
+name: pr-audit
+description: Deep reviewer-side audit of an open PR (by number/URL) — clone+build, cross-file caller tracing, compare with Copilot, post inline + summary review.
+argument-hint: "[pr-number|url] [--mode] [--lang] [--repo owner/name]"
+user-invocable: true
+---
+
+# PR Audit (Reviewer-Side Deep Review)
+
+รีวิว PR ที่เปิดค้างอยู่ **ในฐานะ reviewer** แบบเชิงลึก — clone + build จริง, ไล่ caller ข้ามไฟล์,
+เทียบกับ Copilot/reviewer อื่น แล้วโพสต์ inline conversation + summary review ขึ้น GitHub
+
+> ต่างจาก `/pr` (สร้าง PR ใหม่), `/pr-review` (จัดการ feedback บน PR **ของตัวเอง**), `/review` (รีวิว local diff ก่อน push)
+> `/pr-audit` = ออกรีวิว PR ของคนอื่นฝั่ง reviewer
+
+## Usage
+
+```
+/pr-audit 351                       # รีวิว PR #351 ใน repo ปัจจุบัน (ถามโหมดตอนเริ่ม)
+/pr-audit https://github.com/o/r/pull/351
+/pr-audit 642 --repo owner/name     # รีวิวข้าม repo
+/pr-audit 351 --mode=comment --lang=th   # โพสต์ลง PR เป็นภาษาไทย
+/pr-audit 351 --mode=review              # ดูอย่างเดียว ไม่โพสต์
+```
+
+## Options
+
+| Option | ค่า | Default | ความหมาย |
+|--------|-----|---------|----------|
+| `--mode` | `review` \| `comment` | ถามตอนเริ่ม | `review` = ดู/รายงานใน chat อย่างเดียว, `comment` = โพสต์ inline + summary ลง PR |
+| `--lang` | `th` \| `en` | `th` | ภาษาของ comment ที่โพสต์ (เทียบ `references/language-guide.md`) |
+| `--repo` | `owner/name` | repo ปัจจุบัน | รีวิว PR ข้าม repo |
+
+## Instructions
+
+### Language Setting
+
+> Default `--lang=th`. ถ้าไม่ระบุ ตรวจ `LANGUAGE` ใน `docs/current.md` ด้วย แล้ว fallback เป็น `th`.
+> แปล output ที่ผู้ใช้เห็น/comment ที่โพสต์ตาม `references/language-guide.md`.
+> **คงเป็น English เสมอ:** code, commit hash, file path, line number, technical terms
+
+### Step 0: Parse Arguments & Resolve PR
+
+```bash
+# แยก pr-number / url / flags จาก $ARGUMENTS
+# ตั้ง REPO_FLAG="--repo owner/name" ถ้ามี --repo หรือ url ข้าม repo
+PR=<pr-number>
+REPO_FLAG=""   # เช่น "--repo owner/name"
+
+# ดึง metadata
+gh pr view $PR $REPO_FLAG --json number,title,url,headRefName,baseRefName,headRepository,headRepositoryOwner,state,author,additions,deletions,changedFiles,mergeable
+```
+
+ถ้า `--mode` ไม่ระบุ → **ถาม user** ก่อนว่าจะ `review` (ดูอย่างเดียว) หรือ `comment` (โพสต์ลง PR)
+
+### Step 1: Fetch Diff & File List (กรอง noise)
+
+```bash
+# รายชื่อไฟล์ที่เปลี่ยน
+gh pr diff $PR $REPO_FLAG --name-only
+
+# ดู diff เต็ม (ข้าม lock/generated/vendor)
+gh pr diff $PR $REPO_FLAG
+```
+
+**กรองออกจากการ deep-review** (แต่ยังนับว่ามีการเปลี่ยน): `*.lock`, `go.sum`, `package-lock.json`,
+`*_gen.go`, `*.pb.go`, `dist/`, `vendor/`, `node_modules/`, generated/snapshot files
+
+### Step 2: Clone / Worktree the PR Branch (ไม่แตะ working tree หลัก)
+
+> **Safety:** ห้ามแตะ branch ปัจจุบัน — ใช้ worktree แยก และ cleanup เสมอ (ดู Step 8)
+
+```bash
+# stash ของหลักไว้ก่อน (กันพลาด) — ถ้ามี uncommitted
+git stash push -m "pr-audit-autostash" 2>/dev/null || true
+
+# สร้าง worktree แยกสำหรับ branch ของ PR
+WT=$(mktemp -d -t pr-audit-$PR-XXXX)
+git fetch origin pull/$PR/head:pr-audit-$PR 2>/dev/null \
+  || gh pr checkout $PR $REPO_FLAG --branch pr-audit-$PR   # cross-repo fallback
+git worktree add "$WT" pr-audit-$PR
+echo "Worktree: $WT"
+```
+
+> ข้าม repo (`--repo`): ถ้า PR มาจาก fork ใช้ `gh pr checkout` ซึ่งจัดการ remote ของ fork ให้
+
+### Step 3: Build + Test — **ทำทุกครั้ง (ไม่ optional)**
+
+ใช้ **`build-validator`** subagent บน worktree — ห้ามเขียน build heuristic ซ้ำ
+
+```
+ใช้ Task tool subagent_type="build-validator":
+"Detect project type in <WT> and run build + tests + lint.
+Report PASS/FAIL per check with logs. Working dir: <WT>."
+```
+
+- ถ้า build/test **ไม่ผ่าน** → บันทึกเป็น finding ระดับ **CRITICAL** พร้อม log (ไม่หยุด flow — รายงานต่อ)
+- ผลลัพธ์ build/test ใช้ยืนยัน finding (ดู KB-first ข้อ Step 5 — เช่น dup-import ที่ build ผ่าน)
+
+### Step 4: Deep Review — ไล่ caller ข้ามไฟล์ + cross-layer wiring
+
+ใช้ **`code-reviewer`** subagent หา bug/security/perf — ห้ามเขียน heuristic ซ้ำ
+
+```
+ใช้ Task tool subagent_type="code-reviewer":
+"Review the diff of PR #<PR> at <WT> vs base <baseRef>.
+Beyond per-file issues, trace cross-file wiring:
+- caller → callee across files (signature/contract drift)
+- cross-layer flow (e.g. CI workflow → Dockerfile ARG → app env → runtime)
+- config/proto/schema changes vs their consumers
+Return findings with severity (CRITICAL/WARNING/INFO), file:line, evidence, suggested fix."
+```
+
+เพิ่มการตรวจ cross-layer ที่ subagent มักพลาด (ไล่เองด้วย grep ใน worktree):
+- workflow/CI → Dockerfile (`ARG`/`ENV`) → app — ค่าที่ส่งผ่านครบไหม (เช่น `ARG SITE` หาย → multi-site ไม่สลับธีม)
+- migration/schema → repository/query layer
+- proto/interface → ทั้ง server และ client implementations
+
+### Step 5: KB-First Policy (ก่อน flag known-pattern)
+
+ก่อนจะ flag finding ที่เป็น "known pattern" ให้ค้น KB ก่อน:
+
+```bash
+grep -ri "<keyword>" kb/02-patterns/ kb/03-bugs/ kb/02-patterns/anti-patterns/ 2>/dev/null
+```
+
+- **มี entry ตรง** → ทำตาม KB (ปรับ severity/คำแนะนำตามที่ KB สรุปไว้)
+- **ไม่มี entry** → **หยุดถาม user** + เสนอแนะ แล้วบันทึกเป็น memory/KB ใหม่หลังจบ (Step 9)
+
+**Known-pattern ที่ต้องระวัง** (ดู [known-patterns.md](known-patterns.md)):
+- **dup-import**: import module path เดียวกันคนละ alias → Go **คอมไพล์ได้** อย่า flag เป็น compile error
+  จนกว่าจะ build ยืนยัน (Step 3) — ดู known-patterns.md
+
+### Step 6: Compare with Copilot / Other Reviews
+
+```bash
+# ดึง reviews + review comments ที่มีอยู่
+gh pr view $PR $REPO_FLAG --json reviews,comments
+gh api repos/{owner}/{repo}/pulls/$PR/comments --jq '.[] | {id, path, line, user: .user.login, body}'
+```
+
+- **ตัด finding ที่ซ้ำ** กับ Copilot/reviewer อื่น (ไม่โพสต์ซ้ำ)
+- **ที่ไม่เห็นด้วย** → reply ที่ comment นั้นโดยตรงพร้อม **หลักฐาน** (build log / file:line / KB entry)
+
+### Step 7: Output
+
+#### Mode = review (ดูอย่างเดียว)
+แสดง report ใน chat:
+
+```markdown
+## PR Audit #[number]: [title]   ([owner/repo])
+
+**Build/Test:** PASS / FAIL (รายละเอียด)
+**Findings:** [N] CRITICAL · [N] WARNING · [N] INFO  (ตัดซ้ำ Copilot [N] รายการ)
+
+### CRITICAL
+- `file:line` — [issue] · evidence: [...] · fix: [...]
+
+### WARNING / INFO
+- ...
+
+### vs Copilot
+- เห็นด้วย: [...]
+- ไม่เห็นด้วย: [comment_id] — [เหตุผล + หลักฐาน]
+```
+
+#### Mode = comment (โพสต์ลง PR)
+1. **Inline conversation** ต่อจุดโค้ด (ผูก commit_id + path + line):
+
+```bash
+HEAD_SHA=$(gh pr view $PR $REPO_FLAG --json headRefOid --jq .headRefOid)
+gh api repos/{owner}/{repo}/pulls/$PR/comments \
+  -f body="[finding + suggested fix]" \
+  -f commit_id="$HEAD_SHA" \
+  -f path="<file>" \
+  -F line=<line> \
+  -f side="RIGHT"
+```
+
+2. **Summary review comment** รวมทุกอย่าง (ภาษาตาม `--lang`):
+
+```bash
+gh pr review $PR $REPO_FLAG --comment --body "$(cat <<'EOF'
+## PR Audit Summary
+- Build/Test: [PASS/FAIL]
+- CRITICAL: [N] · WARNING: [N] · INFO: [N]
+- [สรุป findings สำคัญ + cross-file issues]
+EOF
+)"
+```
+
+> เลือก `--comment` (ไม่ block) เป็น default. ใช้ `--request-changes` เฉพาะเมื่อมี CRITICAL และ user ยืนยัน
+> **หมายเหตุ:** submitted review **ลบไม่ได้** (แก้ body ได้), inline comment ลบได้ — โพสต์อย่างระมัดระวัง
+
+### Step 8: Cleanup (เสมอ — แม้ flow ล้มเหลว)
+
+```bash
+git worktree remove "$WT" --force 2>/dev/null
+git branch -D pr-audit-$PR 2>/dev/null
+rm -rf "$WT" 2>/dev/null
+git stash pop 2>/dev/null || true   # คืน working tree เดิม
+```
+
+### Step 9: Update KB (pattern ใหม่)
+
+ถ้าเจอ pattern/anti-pattern ใหม่ที่ยังไม่มีใน KB (Step 5) → บันทึก:
+- เป็น learning: `kb/05-ai-reviewed/learnings/YYYY-MM/DD/HH.MM_[slug].md` หรือ
+- เป็น anti-pattern entry ใน `kb/02-patterns/anti-patterns/`
+
+## Safety Rules (ตาม workspace rules)
+
+| Rule | Detail |
+|------|--------|
+| ห้ามลบไฟล์ผู้ใช้ | review เท่านั้น |
+| ห้าม force push / ห้ามแก้ branch ของ PR | reviewer ไม่ push |
+| stash ก่อนสลับ/cleanup | คืน working tree เดิมเสมอ |
+| ห้าม commit ลง main/develop | ไม่มี commit ในการ audit |
+| cleanup worktree เสมอ | แม้ build ล้มเหลว (Step 8) |
+| GitHub comments | submitted review ลบไม่ได้ (แก้ body ได้), inline ลบได้ |
+
+## Reuse (ห้ามเขียน heuristic ซ้ำ)
+
+| ต้องการ | เรียก |
+|---------|-------|
+| หา bug/security/perf | `code-reviewer` subagent |
+| build/test/lint | `build-validator` subagent |
+| ภาษา output | `references/language-guide.md` |
+
+## Related Commands
+
+| Command | Purpose |
+|---------|---------|
+| `/pr` | สร้าง PR ใหม่ (ฝั่ง author) |
+| `/pr-review` | จัดการ feedback บน PR ของตัวเอง |
+| `/review` | รีวิว local diff ก่อน push |
+| `/pr-audit` | รีวิว PR คนอื่นเชิงลึกฝั่ง reviewer (คุณอยู่ที่นี่) |

--- a/skills/pr-audit/known-patterns.md
+++ b/skills/pr-audit/known-patterns.md
@@ -1,0 +1,43 @@
+# PR Audit — Known Patterns (KB-First Reference)
+
+Known patterns ที่ reviewer มักจะ flag ผิด — ตรวจ KB ก่อนเสมอ (Step 5)
+ถ้าเจอเคสใหม่ที่ไม่อยู่ที่นี่ → หยุดถาม user + บันทึกเป็น KB ใหม่ (Step 9)
+
+## dup-import (Go) — อย่า flag เป็น compile error
+
+**อาการที่เห็น:** import module path เดียวกันถูก import ด้วย alias ต่างกันในไฟล์เดียว/หลายไฟล์
+
+```go
+import (
+    pb "example.com/proto/v1"
+    pbv1 "example.com/proto/v1"   // ดูเหมือนซ้ำ
+)
+```
+
+**ความจริง:** Go **คอมไพล์ผ่าน** ตราบใดที่แต่ละ alias ถูกใช้งานจริง (unused import ต่างหากที่ error)
+การ flag ว่า "duplicate import → compile error" โดยไม่ build = **false positive**
+
+**สิ่งที่ต้องทำ:**
+1. รัน build ก่อน (Step 3) — ถ้า build ผ่าน = ไม่ใช่ compile error
+2. ถ้าจะ flag ให้ flag เป็น **WARNING (style)** ว่า "ควรรวม alias เดียว" ไม่ใช่ CRITICAL
+3. แนบ build log เป็นหลักฐานใน reply
+
+## Cross-Layer Wiring (มักพลาดเพราะดูทีละไฟล์)
+
+| ชั้น | ตรวจอะไร | ตัวอย่างบั๊กจริง |
+|------|----------|------------------|
+| CI/workflow → Dockerfile | `ARG`/`ENV`/build-args ส่งครบไหม | `ARG SITE` หายใน Dockerfile → multi-site build ไม่สลับธีม |
+| Dockerfile → app runtime | env ที่ app อ่าน มีตั้งใน image ไหม | |
+| migration → repository | column/index ที่ query ใช้ ตรงกับ schema ใหม่ไหม | |
+| proto/interface → impl | server + client implement ครบทุก method ไหม | |
+
+> วิธีตรวจ: grep ชื่อ symbol/ARG/env ข้ามไฟล์ใน worktree — อย่าเชื่อ per-file review อย่างเดียว
+
+## วิธีค้น KB ก่อน flag
+
+```bash
+grep -ri "<keyword>" kb/02-patterns/ kb/03-bugs/ kb/02-patterns/anti-patterns/ 2>/dev/null
+```
+
+- มี entry → ทำตาม KB
+- ไม่มี → หยุดถาม user + เสนอแนะ + บันทึกใหม่

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -110,6 +110,8 @@ gh api repos/{owner}/{repo}/issues/{pr_number}/comments --jq '.[] | {id, body, u
 - ห้ามสร้าง comment ใหม่แยกต่างหาก
 - ต้อง reply ไปที่ comment นั้นๆ โดยตรงเท่านั้น
 
+> **Language:** reply bodies ด้านล่าง (6.1–6.5) เป็น template ภาษาอังกฤษ — ถ้า `LANGUAGE: th` ใน `docs/current.md` ให้แปลตามตาราง "**/pr-review Reply Templates (6.1–6.5)**" ใน [language-guide.md](../../references/language-guide.md) ส่วน commit message คงเป็น English เสมอ
+
 **Thread Resolution:** ใช้ helper functions จาก [thread-resolution.md](thread-resolution.md) — `get_thread_id_for_comment(owner, repo, pr_number, comment_id)` และ `resolve_thread(thread_id)`
 
 สำหรับ **แต่ละ comment** ให้ทำแยกกัน:


### PR DESCRIPTION
## สรุป

ปิด 3 issues ที่เปิดค้าง + sync เอกสารการใช้งาน + เพิ่ม CHANGELOG

| Issue | สิ่งที่ทำ |
|-------|-----------|
| #19 | เพิ่ม skill ใหม่ `/pr-audit` — รีวิว PR เชิงลึกฝั่ง reviewer |
| #17 | เพิ่ม Thai reply templates (6.1–6.5) ใน `language-guide.md` |
| #18 | ยืนยันว่า `/pr` รองรับภาษาแล้ว (i18n infra เดิม) — ไม่ต้องแก้โค้ด |

## /pr-audit (#19)

- รับ PR number/URL (รองรับ `--repo owner/name` + cross-repo fork)
- Clone PR branch เข้า **git worktree** แยก (ไม่แตะ working tree หลัก) + **build/test ทุกครั้ง** ผ่าน `build-validator`
- Deep review ผ่าน `code-reviewer` + ตรวจ **cross-layer wiring** (CI workflow → Dockerfile `ARG` → app, migration → repo, proto → impl)
- **KB-first**: ค้น `kb/` ก่อน flag known-pattern, ไม่มี entry → ถาม user + บันทึก KB ใหม่
- เทียบ **Copilot/reviewer** อื่น → ตัดซ้ำ + reply ที่ไม่เห็นด้วยพร้อมหลักฐาน
- 2 โหมด: `--mode=review` (รายงานใน chat) / `--mode=comment` (โพสต์ **inline** + **summary**)
- `--lang=th|en` (default `th`)
- Cleanup worktree เสมอแม้ flow ล้มเหลว
- Companion `known-patterns.md` (Go dup-import = ไม่ใช่ compile error, build ก่อน; cross-layer checklist)

## เอกสาร

- Register `/pr-audit` ใน `SKILL.md`, `README.md` (ตาราง + structure tree)
- Migrate directory-structure docs จาก `docs/` → `kb/` vault layout ให้ตรงกับ skill จริง
- เพิ่ม `CHANGELOG.md` (Keep a Changelog) ครอบคลุม #17/#18/#19 + kb migration + i18n
- `ROADMAP.md`: mark #17/#18/#19 เสร็จใน milestone v1.3

## หมายเหตุ

- Repo เป็น markdown/skills (ไม่มี Makefile) — ไม่มี build/test ให้รัน; ตรวจ conflict markers, frontmatter, และ stale path แล้ว clean

Closes #17
Closes #18
Closes #19